### PR TITLE
move sparkline label up so it is more visible

### DIFF
--- a/index.rmd
+++ b/index.rmd
@@ -403,7 +403,7 @@ rt1 <- df %>%
             height = 40,
             width = 135,
             max = max(region.covid2$cases_cume),
-            margin = list(top = 8, right = 6, bottom = 0, left = 10),
+            margin = list(top = 12, right = 6, bottom = 0, left = 10),
             renderTooltip = htmlwidgets::JS("
               function(_ref) {
                 var datum = _ref.datum;
@@ -434,9 +434,9 @@ rt1 <- df %>%
                 stroke = "#CA0020",
                 fill = "#FFF",
                 size = 3,
-                labelPosition = "left",
-                labelOffset = "8",
-                renderLabel = htmlwidgets::JS("function(d) {return d.toLocaleString(undefined, {maximumFractionDigits:0})}")
+                labelPosition = htmlwidgets::JS("function(d,i) {return {textAnchor: 'end',dx:-6,dy:-6}}"),
+                #labelOffset = 6,
+                renderLabel = htmlwidgets::JS("function(d) { return d.toLocaleString(undefined, {maximumFractionDigits:0}); }")
               ),
               dui_tooltip(
                 components = list(


### PR DESCRIPTION
Move 'Cases over Time' sparkline label up slightly so that it is visible with low case count.  We standardized the y axis meaning counties with low case count would not give us enough room to produce the label with default settings.  Here is a clip after the change.

![image](https://user-images.githubusercontent.com/837910/88664060-1abb8e00-d0a2-11ea-91eb-b049d32acf21.png)
