### PR TITLE
remove double scrollbar which looks like clipping of iframe 

### DIFF
--- a/index.rmd
+++ b/index.rmd
@@ -859,7 +859,7 @@ Strategic Planning Tool  {data-icon="fa-toolbox"}
 
 <!-- this is to fool shinydashboard to not insert into a row-->
 </h5></h5>
-<iframe id="shinyapp" scrolling = "yes" src="https://urbanspatial.shinyapps.io/CV19_Strategic_Planning_App/" style="border: none; width: 100vw; height: 100%; min-height:100vh;" frameborder="0">
+<iframe id="shinyapp" scrolling = "yes" src="https://urbanspatial.shinyapps.io/CV19_Strategic_Planning_App/" style="border: none; width: 100vw; height: 100%; min-height: calc(100vh - 60px);" frameborder="0">
 </iframe>
 
 Row {data-height=0}


### PR DESCRIPTION
This will be 1 of 2 changes to resolve https://github.com/dcb5006/COVIDAid/issues/5.  The other will be made in shiny app iframe.